### PR TITLE
fix: vargos chat command should not require dev dependencies

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -131,9 +131,25 @@ if (cmd === 'start') {
 
 // chat subcommand
 if (cmd === 'chat') {
+  // Seed data dir first (replaces tsx scripts/seed.ts)
+  const paths = getDataPaths();
+  const { createLogger } = await import('./lib/logger.js');
+  const log = createLogger('seed');
+  await (await import('./lib/templates.js')).seedDataDir(paths.dataDir, log);
+
+  // Then run pi CLI with environment variables
   const { execSync } = await import('node:child_process');
-  execSync('pnpm chat', { stdio: 'inherit', cwd: import.meta.dirname });
-  process.exit(0);
+  const dataDir = paths.dataDir;
+  const agentDir = `${dataDir}/agent`;
+
+  execSync(`pi --session-dir "${dataDir}/sessions/cli"`, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      PI_CODING_AGENT_DIR: agentDir,
+      VARGOS_DATA_DIR: dataDir,
+    },
+  });
 }
 
 // No command — first-run or help

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chozzz/vargos",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "packageManager": "pnpm@10.33.2",
   "description": "Self-hosted agent OS with persistent memory, multi-channel presence, tools, scheduling, and sub-agent orchestration",
   "license": "Apache-2.0",


### PR DESCRIPTION

## Summary
Fixed `vargos chat` failing on global npm installations due to missing dev dependencies (pnpm, tsx).

## Changes
- Removed dependency on `pnpm chat` shell execution
- Now directly imports seedDataDir function from compiled lib
- Runs pi CLI with required environment variables
- No longer requires dev dependencies when installed globally

Bump to 2.0.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
