### PR TITLE
fix: resolve pi CLI path for global npm installs

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -30,7 +30,7 @@ if (v[0] < MIN_NODE) {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const VERSION = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).version;
+const VERSION = JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf8')).version;
 
 function usage(): void {
   console.log(`
@@ -142,7 +142,24 @@ if (cmd === 'chat') {
   const dataDir = paths.dataDir;
   const agentDir = `${dataDir}/agent`;
 
-  execSync(`pi --session-dir "${dataDir}/sessions/cli"`, {
+  // Find pi CLI via node_modules (required for global npm installs)
+  let piCliPath = 'pi';
+  try {
+    // Search for pi package in node_modules up the tree
+    let searchDir = __dirname;
+    while (searchDir !== '/') {
+      const piPath = path.join(searchDir, 'node_modules', '@mariozechner', 'pi-coding-agent', 'dist', 'cli.js');
+      if (existsSync(piPath)) {
+        piCliPath = piPath;
+        break;
+      }
+      searchDir = path.dirname(searchDir);
+    }
+  } catch {
+    // fallback to 'pi' command
+  }
+
+  execSync(`node "${piCliPath}" --session-dir "${dataDir}/sessions/cli"`, {
     stdio: 'inherit',
     env: {
       ...process.env,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chozzz/vargos",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "packageManager": "pnpm@10.33.2",
   "description": "Self-hosted agent OS with persistent memory, multi-channel presence, tools, scheduling, and sub-agent orchestration",
   "license": "Apache-2.0",


### PR DESCRIPTION

## Summary
Fixed 'vargos chat' failing on global npm installations by resolving the pi CLI path from node_modules.

## Problem
When installed globally via npm, the 'pi' CLI from @mariozechner/pi-coding-agent is not in PATH, causing 'vargos chat' to fail.

## Solution
- Search for pi's dist/cli.js in node_modules hierarchy
- Execute it with node directly instead of relying on PATH
- Fall back to 'pi' command if path can't be found (for local development)

Also fixed VERSION reading to use correct package.json path.

Bump to 2.0.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
