### PR TITLE
Release v3.1.1 — model fallback + session-cleanup race fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,5 @@
 /agent/ @chozzz
 
 # Critical configuration
-CLAUDE.md @chozzz
 package.json @chozzz
 .github/ @chozzz

--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,9 @@ npm-debug.log*
 
 # AI assistant settings
 .claude/
+CLAUDE.md
 .cursor/
 .qwen/
-CLAUDE.md
 
 # Internal tasks and plans
 docs/tasks/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ pnpm lint             # eslint + typecheck
 - **Config**: `~/.vargos/config.json` + `~/.vargos/agent/{mcp,models,settings,auth}.json`. MCP servers configured in `agent/mcp.json` (shared with Pi SDK); others consolidated by `services/config`.
 - **API keys**: provider entries in `agent/models.json`; env `${PROVIDER}_API_KEY` overrides.
 - **Skills**: auto-loaded from `~/.vargos/agent/skills/`, `~/.vargos/workspace/skills/`, `<cwd>/skills/`, `<cwd>/.pi/skills/`. Pi SDK injects `name` + `description`; body is read on demand. Bundled: `skill-creator`.
-- **Bootstrap files**: only `AGENTS.md`, `SOUL.md`, `TOOLS.md` from workspace + cwd are merged into the system prompt (`services/agent/index.ts:365`). `CLAUDE.md` is **not** in this list — Pi SDK auto-discovers it from cwd separately as `# Project Context`.
+- **Bootstrap files**: only `AGENTS.md`, `SOUL.md`, `TOOLS.md` from workspace + cwd are merged into the system prompt (`services/agent/index.ts:365`). Pi SDK auto-discovers `AGENTS.md` from cwd separately as `# Project Context`.
 - **Channel personas**: per-channel system-prompt overrides at `~/.vargos/agents/<channelId>.md`. Frontmatter `allowedTools?: string[]` (glob whitelist applied to bus tools); body appended after bootstrap. `default.md` seeds new channels at boot.
 - **Reply or Cross-channel forwarding**: `channel.send` with `fromSessionKey` injects `[fromSessionKey] text` into target session history via `agent.appendMessage` (no agent run on receiver).
 - **Directives**: `/think:<level>`, `/verbose` parsed by `services/agent/directives.ts` before agent runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,0 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-Refer to AGENTS.md instead - Do not use this.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,7 +26,7 @@ Pi-SDK-powered runtime (`@mariozechner/pi-coding-agent`) with Vargos-managed con
 |---------|--------|
 | Bootstrap files merged from workspace + cwd: `AGENTS.md`, `SOUL.md`, `TOOLS.md` | ✅ |
 | 6K char head/tail truncation per file | ✅ |
-| Pi SDK auto-discovers cwd-tree `CLAUDE.md`/`AGENTS.md` separately as `# Project Context` | ✅ |
+| Pi SDK auto-discovers cwd-tree `AGENTS.md` separately as `# Project Context` | ✅ |
 | Skills metadata block (Pi SDK injects name + description + location) | ✅ |
 | Channel persona body appended after bootstrap | ✅ |
 | Interpolation: `${WORKSPACE_DIR}`, `${DATA_DIR}`, `${SESSION_KEY}`, `${CHANNEL_ID}`, `${CHAT_ID}`, `${USER_ID/NAME/HANDLE}`, `${BOT_ID/NAME/HANDLE}`, `${CURRENT_DATE}`, `${CURRENT_TIMEZONE}`, `${VAR:-default}` | ✅ |

--- a/docs/usage/runtime.md
+++ b/docs/usage/runtime.md
@@ -31,8 +31,8 @@ In order:
 
 1. **Pi SDK base prompt** — built-in agent instructions.
 2. **Pi SDK skills metadata** — `<available_skills>` block (name + description + location only). Skill bodies are read on demand via the `read` tool (Anthropic's progressive-disclosure pattern). Discovery roots: see [Skills](../extending/skills.md).
-3. **Pi SDK context files** — auto-walked from `cwd`: `AGENTS.md` or `CLAUDE.md` per ancestor directory. Rendered as `# Project Context`.
-4. **Vargos bootstrap files** — `AGENTS.md`, `SOUL.md`, `TOOLS.md` from `<workspaceDir>` and `<cwd>`. Each head/tail-truncated at 6K chars. `CLAUDE.md` is intentionally **not** in this list — Pi SDK handles it via step 3.
+3. **Pi SDK context files** — auto-walked from `cwd`: `AGENTS.md` per ancestor directory. Rendered as `# Project Context`.
+4. **Vargos bootstrap files** — `AGENTS.md`, `SOUL.md`, `TOOLS.md` from `<workspaceDir>` and `<cwd>`. Each head/tail-truncated at 6K chars.
 5. **Channel persona body** — content of `~/.vargos/agents/<channelId>.md` (see [Personas](./personas.md)).
 6. **Interpolation** — every `${VAR}` and `${VAR:-default}` replaced. Available variables: paths (`WORKSPACE_DIR`, `DATA_DIR`, etc.), time (`CURRENT_DATE`, `CURRENT_TIMEZONE`), session (`SESSION_KEY`), and documentation placeholders (`PROVIDER`, `VAR`). See [Configuration](../configuration.md#interpolation-variables).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chozzz/vargos",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "packageManager": "pnpm@10.33.2",
   "description": "Self-hosted agent OS with persistent memory, multi-channel presence, tools, scheduling, and sub-agent orchestration",
   "license": "Apache-2.0",

--- a/services/agent/__tests__/agent.helpers.test.ts
+++ b/services/agent/__tests__/agent.helpers.test.ts
@@ -10,8 +10,8 @@ import { truncate } from '../../../lib/truncate.js';
 // ── Helper methods testing ───────────────────────────────────────────────────
 
 class TestableRuntime extends AgentService {
-  testValidateModel(modelSpec: string): void {
-    return this['validateModel'](modelSpec);
+  testIsValidModel(modelSpec: string): boolean {
+    return this['isValidModel'](modelSpec);
   }
 }
 
@@ -42,7 +42,7 @@ function createTestRuntime(dataDir: string): TestableRuntime {
   return runtime;
 }
 
-describe('validateModel', () => {
+describe('isValidModel', () => {
   let tmpDir: string;
   let runtime: TestableRuntime;
   let originalEnv: string | undefined;
@@ -58,28 +58,17 @@ describe('validateModel', () => {
     resetDataPaths();
   });
 
-  it('throws on invalid provider', () => {
-    expect(() => {
-      runtime.testValidateModel('nonexistent:model');
-    }).toThrow('Model not found: nonexistent:model');
+  // Invalid model ids return false (the caller falls back to the default instead of throwing).
+  it('returns false for an unknown provider', () => {
+    expect(runtime.testIsValidModel('nonexistent:model')).toBe(false);
   });
 
-  it('throws on invalid model id', () => {
-    expect(() => {
-      runtime.testValidateModel('test:nonexistent');
-    }).toThrow('Model not found: test:nonexistent');
+  it('returns false for an unknown model id', () => {
+    expect(runtime.testIsValidModel('test:nonexistent')).toBe(false);
   });
 
-  it('throws on malformed spec (missing colon)', () => {
-    expect(() => {
-      runtime.testValidateModel('invalid-spec');
-    }).toThrow();
-  });
-
-  it('error message includes format hint', () => {
-    expect(() => {
-      runtime.testValidateModel('test:invalid');
-    }).toThrow('Expected format: provider:modelId');
+  it('returns false for a malformed spec (missing colon)', () => {
+    expect(runtime.testIsValidModel('invalid-spec')).toBe(false);
   });
 });
 

--- a/services/agent/index.ts
+++ b/services/agent/index.ts
@@ -145,7 +145,7 @@ export class AgentService {
        */
       task: z.string().describe('The task to execute.'),
       cwd: z.string().optional().describe('Working directory for the agent — defaults to workspace dir.'),
-      model: z.string().optional().describe('Model override in format provider:modelId (e.g., "claude-opus-4").'),
+      model: z.string().optional().describe('Optional model override as "provider:modelId" (e.g. "anthropic:claude-opus-4"). Omit to use the agent default — an unknown value falls back to the default.'),
     }),
   })
   async execute(params: EventMap['agent.execute']['params']): Promise<EventMap['agent.execute']['result']> {
@@ -155,14 +155,18 @@ export class AgentService {
 
     log.debug(`execute: START ${params.sessionKey}`);
 
-    if (params.model) {
-      this.validateModel(params.model);
+    // Fall back to the session's default model when the override is missing or unknown,
+    // instead of failing the run (agents sometimes pass an ill-formed or stale model id).
+    let model = params.model;
+    if (model && !this.isValidModel(model)) {
+      log.warn(`agent.execute: ignoring invalid model "${model}" (expected provider:modelId) — using default`);
+      model = undefined;
     }
 
     const directives = parseDirectives(params.task);
     const task = interpolatePrompt(directives.cleaned || params.task);
 
-    const session = await this.getOrCreateSession(params.sessionKey, { cwd: params.cwd, model: params.model });
+    const session = await this.getOrCreateSession(params.sessionKey, { cwd: params.cwd, model });
 
     if (directives.thinkingLevel) {
       session.setThinkingLevel(directives.thinkingLevel);
@@ -471,12 +475,9 @@ export class AgentService {
   /**
    * Validate model override if provided.
    */
-  private validateModel(modelSpec: string): void {
+  private isValidModel(modelSpec: string): boolean {
     const [provider, modelId] = modelSpec.split(':');
-    const model = this.modelRegistry.find(provider, modelId);
-    if (!model) {
-      throw new Error(`Model not found: ${modelSpec}. Expected format: provider:modelId`);
-    }
+    return !!this.modelRegistry.find(provider, modelId);
   }
 
   // ── Private Helpers ────────────────────────────────────────────────────────

--- a/services/channels/__tests__/e2e/channels.e2e.test.ts
+++ b/services/channels/__tests__/e2e/channels.e2e.test.ts
@@ -458,7 +458,7 @@ describe('onAgentCompleted reply logic', () => {
     expect(adapter.typingStopped).toContainEqual({ sessionKey, final: true });
   });
 
-  it('keeps session alive after completion (for multiple turn_end events)', async () => {
+  it('removes the session on completion (agent_end fires once per run)', async () => {
     const { bus, svc, adapter } = setup();
     const sessionKey = 'stub-ch:user5';
 
@@ -467,8 +467,8 @@ describe('onAgentCompleted reply logic', () => {
     bus.emit('agent.onCompleted', { sessionKey, success: true, response: '' });
     await tick();
 
-    // Session stays alive to handle multiple agent.onCompleted events
-    expect((svc as any).activeSessions.has(sessionKey)).toBe(true);
+    // Completion is the cleanup anchor — the session is removed.
+    expect((svc as any).activeSessions.has(sessionKey)).toBe(false);
   });
 
   it('calls reactionController.setDone and dispose on success', async () => {
@@ -513,7 +513,7 @@ describe('onAgentCompleted reply logic', () => {
     expect(adapter.sent).toHaveLength(0);
   });
 
-  it('second onAgentCompleted for same sessionKey processes both (session stays alive)', async () => {
+  it('a duplicate/late onAgentCompleted after cleanup is a safe no-op', async () => {
     const { bus, svc, adapter } = setup();
     const sessionKey = 'stub-ch:user8';
 
@@ -521,12 +521,12 @@ describe('onAgentCompleted reply logic', () => {
 
     bus.emit('agent.onCompleted', { sessionKey, success: true, response: '' });
     await tick();
-    // Fire again — session is still alive, so it processes
+    // First completion removed the session; a second event finds nothing and is ignored.
     bus.emit('agent.onCompleted', { sessionKey, success: true, response: '' });
     await tick();
 
-    // stopTyping called twice (once for each completion)
-    expect(adapter.typingStopped.filter(t => t.sessionKey === sessionKey)).toHaveLength(2);
+    expect((svc as any).activeSessions.has(sessionKey)).toBe(false);
+    expect(adapter.typingStopped.filter(t => t.sessionKey === sessionKey)).toHaveLength(1);
   });
 
   it('uses Unknown error message when error field is absent on failure', async () => {
@@ -969,9 +969,7 @@ describe('completion: agent errors deliver exactly one reply', () => {
     expect(adapter.sent[0].text).toContain('provider boom');
   });
 
-  it('session lives for the whole run and is cleaned up when execute settles (no timer)', async () => {
-    // A late onCompleted (e.g. a steered second turn) must still find the session — it is
-    // only removed when agent.execute settles, not on a wall-clock timer.
+  it('session is cleaned up on completion, not on a timer', async () => {
     const { bus, svc, adapter } = setup();
     const sessionKey = 'stub-ch:userRUN';
     let release!: () => void;
@@ -984,8 +982,8 @@ describe('completion: agent errors deliver exactly one reply', () => {
         schema: z.object({ sessionKey: z.string(), task: z.string() }).passthrough(),
       })
       async execute(p: any) {
+        await gate;                  // hold the run open
         bus.emit('agent.onCompleted', { sessionKey: p.sessionKey, success: true, response: 'done' });
-        await gate; // hold the run open after the completion event
         return { response: 'done' };
       }
     }
@@ -993,15 +991,53 @@ describe('completion: agent errors deliver exactly one reply', () => {
 
     await svc.onInboundMessage(sessionKey, createTestMessage('hi'));
     await flush();
-
-    // Run still open → session present (no timer tore it down), reply delivered
-    expect((svc as any).activeSessions.has(sessionKey)).toBe(true);
-    expect(adapter.sent.some(s => s.text === 'done')).toBe(true);
+    expect((svc as any).activeSessions.has(sessionKey)).toBe(true);  // run open, not torn down
 
     release();
     await flush();
+    expect(adapter.sent.some(s => s.text === 'done')).toBe(true);
+    expect((svc as any).activeSessions.has(sessionKey)).toBe(false); // removed on completion
+  });
 
-    // execute settled → session removed
+  it('a second message during an active run steers in without dropping the first run reply', async () => {
+    // Reproduces the production race: a steered message's agent.execute settles early; it must
+    // not delete the session out from under the still-running first run.
+    const { bus, svc, adapter } = setup();
+    const sessionKey = 'stub-ch:userSTEER';
+    let release!: () => void;
+    const gate = new Promise<void>(r => { release = r; });
+    let calls = 0;
+
+    class AgentStub {
+      constructor(b: EventEmitterBus) { b.bootstrap(this); }
+      @register('agent.execute', {
+        description: 'stub',
+        schema: z.object({ sessionKey: z.string(), task: z.string() }).passthrough(),
+      })
+      async execute(p: any) {
+        calls++;
+        if (calls === 1) {
+          await gate; // first run owns the session; completes only when released
+          bus.emit('agent.onCompleted', { sessionKey: p.sessionKey, success: true, response: 'final answer' });
+          return { response: 'final answer' };
+        }
+        return { response: '' }; // steered message: settles early
+      }
+    }
+    new AgentStub(bus);
+
+    await svc.onInboundMessage(sessionKey, createTestMessage('first'));
+    await flush();
+    expect((svc as any).activeSessions.has(sessionKey)).toBe(true);
+
+    await svc.onInboundMessage(sessionKey, createTestMessage('second')); // steers into active run
+    await flush();
+    expect(calls).toBe(2);
+    expect((svc as any).activeSessions.has(sessionKey)).toBe(true);      // not dropped by the early-settled steer
+
+    release();
+    await flush();
+    expect(adapter.sent.some(s => s.text === 'final answer')).toBe(true); // reply delivered, not lost
     expect((svc as any).activeSessions.has(sessionKey)).toBe(false);
   });
 

--- a/services/channels/index.ts
+++ b/services/channels/index.ts
@@ -289,15 +289,20 @@ export class ChannelService {
       return;
     }
 
-    // Claim the session synchronously so the pipeline's catch won't also send (double-send).
+    // agent.onCompleted (pi's agent_end) fires once at the true end of the run — even with
+    // steering, where a second message's agent.execute settles early. So THIS is the cleanup
+    // anchor, not the execute promise: claim + remove the session now. The captured `session`
+    // object still serves the async reply send + reaction seal below. `completed` guards the
+    // pipeline catch against a double-send.
     session.completed = true;
+    this.activeSessions.delete(payload.sessionKey);
 
     const sessionKey = payload.sessionKey;
     const text = payload.success ? (payload.response ?? '') : `Error: ${payload.error || 'Unknown error'}`;
     log.info(`→ ${sessionKey} ${payload.success ? '✓' : '✗'} (${text.length} chars)`);
 
     // Send on error (always), or on a successful response the agent didn't already deliver
-    // via the channel-send tool. The session stays alive for any follow-up completion events.
+    // via the channel-send tool.
     const shouldSend = !payload.success || (!session.replied && !!payload.response);
     const finalize = () => this.pipeline.finalize(session, sessionKey, payload.success !== false);
 

--- a/services/channels/pipeline.ts
+++ b/services/channels/pipeline.ts
@@ -83,8 +83,18 @@ export class InboundMessagePipeline {
       return;
     }
 
-    // Start typing and setup reaction controller
     adapter.startTyping(sessionKey, true);
+
+    // If a run is already in flight for this chat, steer the new message into it: pi injects it
+    // into the active session. Don't create a competing session/completion handler — a single
+    // sessionKey has one activeSessions slot, and a second run racing cleanup is what dropped
+    // replies (its agent.execute can settle early under steering while the real run continues).
+    if (activeSessions.has(sessionKey)) {
+      log.info(`← ${sessionKey} (steer) "${enrichedContent.slice(0, 80)}"`);
+      this.bus.call('agent.execute', { sessionKey, task: enrichedContent, ...(cwd && { cwd }), ...(model && { model }) })
+        .catch(err => log.error(`steered agent.execute failed: ${toMessage(err)}`));
+      return;
+    }
 
     const messageId = adapter.extractLatestMessageId(target.userId);
     let reactionController: StatusReactionController | undefined;
@@ -102,16 +112,10 @@ export class InboundMessagePipeline {
 
     log.info(`← ${sessionKey} "${enrichedContent.slice(0, 80)}"`);
 
-    // Cleanup is anchored to the agent.execute promise, not a timer — and it cannot race
-    // onAgentCompleted. pi awaits every `agent_end` listener before prompt() resolves
-    // (@earendil-works/pi-agent-core agent.js), and our listener synchronously emits
-    // agent.onCompleted — so onAgentCompleted has already looked up this session before
-    // execute settles and `finally` runs (its reply send holds the session by closure, so the
-    // delete can't affect it). Completion (success and error) is handled by onAgentCompleted;
-    // this catch only covers a rejection that arrives WITHOUT a completion event (a
-    // pre-execution failure), guarded by `completed` against double-send. bus.call always
-    // settles (the agent caps itself at 30 min), so no timer is needed and the session can't leak.
-    // NOTE: depends on pi awaiting agent_end listeners before resolving prompt(); revisit on pi bumps.
+    // Cleanup is owned by onAgentCompleted (pi's agent_end fires once at the true end of the
+    // run, even under steering where a second message's agent.execute settles early). This catch
+    // only covers a rejection that arrives WITHOUT a completion event (a pre-execution failure),
+    // guarded by `completed` so it never double-sends or fights onAgentCompleted's cleanup.
     this.bus.call('agent.execute', {
       sessionKey,
       task: enrichedContent,
@@ -122,14 +126,9 @@ export class InboundMessagePipeline {
       const errorMsg = toMessage(err);
       log.error(`agent execution failed before completion: ${errorMsg}`);
       this.finalize(session, sessionKey, false);
+      if (activeSessions.get(sessionKey) === session) activeSessions.delete(sessionKey);
       this.bus.call('channel.send', { sessionKey, text: `System error: ${errorMsg}` })
         .catch(sendErr => log.error(`failed to send error message: ${toMessage(sendErr)}`));
-    }).finally(() => {
-      // Only remove our own entry — a newer run for the same key may have replaced it.
-      if (activeSessions.get(sessionKey) === session) {
-        log.debug(`session ended, cleaning up: ${sessionKey}`);
-        activeSessions.delete(sessionKey);
-      }
     });
   }
 


### PR DESCRIPTION
## v3.1.1

### Fixes
- **`agent.execute` no longer fails on an unknown `model` override** — it logs and falls back to the session default (`isValidModel` replaces the throwing `validateModel`). Also fixed the param description whose example (`claude-opus-4`) violated its own `provider:modelId` format, which is what made agents pass it.
- **`session not found` / dropped replies** — cleanup is now anchored to `agent.onCompleted` (pi's `agent_end`, once per run) instead of the `agent.execute` promise. Under rapid messages + steering, a second `execute` settles early and its old `.finally` deleted the session out from under the still-running first run. Added a steer-in guard so a message during an active run is injected (not given a competing session), and removed the `.finally` (the catch stays for pre-execution rejections only).

Includes the workspace AGENTS.md "Reducing Complexity" directive and the CLAUDE.md→AGENTS.md consolidation already on dev.

Regression tests added (steer race, model fallback, completion cleanup). 477/477 tests · lint clean · Node 22/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)