### PR TITLE
Release v3.1.2 — stable process cwd

### DIFF
--- a/boot.ts
+++ b/boot.ts
@@ -1,6 +1,8 @@
+import { mkdirSync } from 'node:fs';
 import { EventEmitterBus } from './gateway/emitter.js';
 import { startTCPServer } from './gateway/tcp-server.js';
 import { createLogger } from './lib/logger.js';
+import { getDataPaths } from './lib/paths.js';
 import { seedDataDir } from './lib/templates.js';
 import { runMigrations } from './lib/migrate.js';
 import { z } from 'zod';
@@ -34,6 +36,14 @@ if (new Set(labels).size !== labels.length) {
 const RESTART_EXIT_CODE = 42;
 const bus = new EventEmitterBus();
 const log = createLogger('boot');
+
+// Run from a stable, vargos-owned cwd. A long-running agent can delete or relocate the
+// directory vargos was launched from (e.g. a project tree it's auditing). If that's our
+// process cwd, process.cwd() throws ENOENT and crashes child spawns (the MCP `npm install`)
+// and ${PWD} interpolation. ~/.vargos always exists and the agent never touches it.
+const dataDir = getDataPaths().dataDir;
+mkdirSync(dataDir, { recursive: true });
+process.chdir(dataDir);
 const serviceStops = new Map<string, () => unknown>(); // label → stop(); kept current across restarts
 let tcpStop: (() => unknown) | undefined;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chozzz/vargos",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "packageManager": "pnpm@10.33.2",
   "description": "Self-hosted agent OS with persistent memory, multi-channel presence, tools, scheduling, and sub-agent orchestration",
   "license": "Apache-2.0",

--- a/services/agent/prompt-interpolate.ts
+++ b/services/agent/prompt-interpolate.ts
@@ -61,6 +61,10 @@ function interpolatePromptWithMissing(prompt: string, context?: Record<string, s
   const paths = getDataPaths();
   const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+  // process.cwd() throws if the working directory was removed; fall back to the data dir.
+  let pwd: string;
+  try { pwd = process.cwd(); } catch { pwd = paths.dataDir; }
+
   const variables: Record<string, string> = {
     DATA_DIR: paths.dataDir,
     WORKSPACE_DIR: paths.workspaceDir,
@@ -70,7 +74,7 @@ function interpolatePromptWithMissing(prompt: string, context?: Record<string, s
     LOGS_DIR: paths.logsDir,
     CHANNELS_DIR: paths.channelsDir,
     HOME: os.homedir(),
-    PWD: process.cwd(),
+    PWD: pwd,
     CURRENT_DATE: new Date().toLocaleString(undefined, {
       timeZone: currentTimezone,
       year: 'numeric', month: 'long', day: '2-digit',


### PR DESCRIPTION
## v3.1.2

### Fix
- **`process.cwd()` ENOENT crash** (`uv_cwd … working directory was likely removed`). A long-running agent can delete/relocate the directory vargos was launched from (e.g. a project tree it audits); if that's the process cwd, `process.cwd()` throws — crashing pi's `npm install pi-mcp-adapter` child spawn and `${PWD}` interpolation.
  - `boot.ts` now `chdir`s to `~/.vargos` (always exists, agent never touches it) at startup, so the process cwd stays valid for its whole life and child spawns inherit it.
  - `${PWD}` interpolation falls back to the data dir if `process.cwd()` throws.

477/477 tests · lint clean · Node 22/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)